### PR TITLE
起動できるようにポート変更、不要なものを削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,17 @@
 version: "3.9"
 volumes:
   db-store:
-  psysh-store:
 services:
   app:
     build:
       context: .
       dockerfile: ./infra/docker/node/Dockerfile
     ports:
-      - 80:8080
+      - 8080:8080
     volumes:
       - type: bind
         source: ./src
         target: /app/src
-      - type: volume
-        source: psysh-store
-        target: /root/.config/psysh
-        volume:
-          nocopy: true
     environment:
       - DB_CONNECTION=${DB_CONNECTION:-mysql}
       - DB_HOST=${DB_HOST:-db}

--- a/infra/docker/node/Dockerfile
+++ b/infra/docker/node/Dockerfile
@@ -1,11 +1,13 @@
-FROM node:18-alpine3.17 AS base
+FROM node:18
 
 WORKDIR /app
 
 COPY package.json .
 
+COPY ./src /app/src
+
 RUN npm install
 
 EXPOSE 8080
 
-CMD [ "npm", "start" ]
+CMD ["npm", "start"]


### PR DESCRIPTION
変更点としては、以下です。
- ローカルで起動しなかったため、`docker-compose.yaml`のポート情報を変更。
- 本来nodeしかバックエンドに使用しないが、php関連のライブラリを入れていた為削除。